### PR TITLE
fix Dockerfile base image to Python 3.12 for jaclang compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Install Node.js (for Bun) and system deps
 RUN apt-get update && \


### PR DESCRIPTION
jaclang>=0.10.3 requires Python >=3.12.